### PR TITLE
Fix to use the real USB device (not default ttyACM0)

### DIFF
--- a/server/services/zigbee2mqtt/lib/installZ2mContainer.js
+++ b/server/services/zigbee2mqtt/lib/installZ2mContainer.js
@@ -2,7 +2,7 @@ const { promisify } = require('util');
 const { exec } = require('../../../utils/childProcess');
 const { CONFIGURATION } = require('./constants');
 const { EVENTS, WEBSOCKET_MESSAGE_TYPES } = require('../../../utils/constants');
-let containerDescriptor = require('../docker/zigbee2mqtt-container.json');
+const containerDescriptor = require('../docker/zigbee2mqtt-container.json');
 const logger = require('../../../utils/logger');
 
 const sleep = promisify(setTimeout);


### PR DESCRIPTION
### Pull Request check-list

To ensure your Pull Request can be accepted as fast as possible, make sure to review and check all of these items:

- [x] If your changes affects code, did your write the tests?
- [x] Are tests passing? (`npm test` on both front/server)
- [x] Is the linter passing? (`npm run eslint` on both front/server)
- [x] Did you run prettier? (`npm run prettier` on both front/server)
- [x] If you are adding a new features/services, did you run integration comparator? (`npm run compare-translations` on front)
- [x] If your changes modify the API (REST or Node.js), did you modify the API documentation? (Documentation is based on comments in code)
- [x] If you are adding a new features/services which needs explanation, did you modify the user documentation? See [the GitHub repo](https://github.com/GladysAssistant/v4-website) and the [website](https://gladysassistant.com).
- [x] Did you add fake requests data for the demo mode (`front/src/config/demo.json`) so that the demo website is working without a backend? (if needed) See [https://demo.gladysassistant.com](https://demo.gladysassistant.com).

NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open.

### Description of change

Config file `services/zigbee2mqtt/docker/zigbee2mqtt-container.json` is read at the beginning of the file and updated after that.
This generate a bug, as the zigbee device chosen by the user is not used, only the default device already present on the file is used.
Finally, the `zigbee2mqtt-env` file was called without the device as an argument.
